### PR TITLE
Make weblas fail gracefully when there is no webgl support (like three.js)

### DIFF
--- a/lib/webgl.js
+++ b/lib/webgl.js
@@ -37,8 +37,11 @@ function WebGL(options) {
 	glOptions = { premultipliedAlpha: false, preserveDrawingBuffer: false };
 	this.context = this.canvas.getContext("experimental-webgl", glOptions);
 
-	if (typeof this.context === 'undefined')
-		throw new Error("No support for Webgl.");
+	if (this.context == null) {
+	        console.warn('No support for WebGL!');
+	        return;
+	}
+		
 
 	// float texture extension
 	try {
@@ -268,7 +271,11 @@ WebGL.prototype.bindInputTexture = function(texture, textureUnit, name){
 WebGL.prototype.createProgram = function(fragmentShaderSource){
 	var gl = this.context,
 		fragmentShader;
-
+        if (gl == null) {
+                console.warn('No support for WebGL!');
+                return;
+        }
+        
 	// compile the provided fragment/texture shader
 	fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
 	gl.shaderSource(fragmentShader, fragmentShaderSource);


### PR DESCRIPTION
When there is no WebGL support, including weblas in a <script> tag, directly or indirectly via a bundled js, causes `Uncaught TypeError: Cannot read property X of null` (null pointer exception on this.context). This makes running tests on machines without webgl automatically fail, unless the user wraps the whole weblas in a try catch, which can't be done when referenced via a <script> tag.
