### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ First, include the `weblas.js` file (from a release or the `dist` directory).
 <script type="text/javascript" src="weblas.js"></script>
 ```
 
+Or include it via CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/weblas/dist/weblas.js"></script>
+```
+
 Then use it like this.
 
 ```html


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/weblas) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.